### PR TITLE
Follow the latest releases

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,9 @@ ENTRYPOINT ["ffmpeg"]
 
 WORKDIR /work
 
-ENV TARGET_VERSION=3.2.2 \
-    LIBVA_VERSION=1.7.3 \
-    LIBDRM_VERSION=2.4.70 \
+ENV TARGET_VERSION=3.3 \
+    LIBVA_VERSION=1.8.1 \
+    LIBDRM_VERSION=2.4.80 \
     SRC=/usr \
     PKG_CONFIG_PATH=/usr/lib/pkgconfig
 
@@ -32,7 +32,7 @@ RUN yum install -y --enablerepo=extras epel-release yum-utils && \
     rm -rf ${DIR} && \
     # Build libva-intel-driver
     DIR=$(mktemp -d) && cd ${DIR} && \
-    curl -sL https://www.freedesktop.org/software/vaapi/releases/libva-intel-driver/libva-intel-driver-${LIBVA_VERSION}.tar.bz2 | \
+    curl -sL https://www.freedesktop.org/software/vaapi/releases/libva-intel-driver/intel-vaapi-driver-${LIBVA_VERSION}.tar.bz2 | \
     tar -jx --strip-components=1 && \
     ./configure && \
     make && make install && \


### PR DESCRIPTION
- ffmpeg 3.3
- libva 1.8.1
- libdrm 2.4.80

In my environment (Intel Core i3-4130T), the video converted to h.264 with VAAPI had **not** been playable on the QuickTime on Mac somehow. These updates solved the issue.

Note `libva-intel-driver`'s file name has been changed to `intel-vaapi-driver-*` from 1.8.1.